### PR TITLE
remove saving image separately

### DIFF
--- a/P8-Uploading-Photos-Parse/content.md
+++ b/P8-Uploading-Photos-Parse/content.md
@@ -47,7 +47,6 @@ Here's one possible implementation for the callback:
     photoTakingHelper = PhotoTakingHelper(viewController: self.tabBarController!, callback: { (image: UIImage?) in
       let imageData = UIImageJPEGRepresentation(image, 0.8)
       let imageFile = PFFile(data: imageData)
-      imageFile.save()
 >
       let post = PFObject(className: "Post")
       post["imageFile"] = imageFile
@@ -56,7 +55,7 @@ Here's one possible implementation for the callback:
 
 There shouldn't be too many surprises in these lines. The most interesting one is the very first one. We turn the `UIImage` into an `NSData` instance because the `PFFile` class needs an `NSData` argument for its initializer.
 
-Then we create and `save` the `PFFile`.
+Then we create `imageFile`, the `PFFile`.
 
 In the next step we create a `PFObject` of type post. We assign the `"imageFile"` to this post and then save it as well.
 


### PR DESCRIPTION
We no longer need to worry about saving Parse pointer objects before the object that points to is is saved, Parse will handle all of this for us. This also solves an issue in the code that would end the background task when the image was done uploading, leaving the Post vulnerable to being cancelled early.
